### PR TITLE
Allow to subscribe on multiple routing keys on same queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jackhammer (1.0.0)
+    jackhammer (1.1.0)
       bunny (~> 2.14)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ default: &default
     auto_delete: false
     durable: true
     queues:
+      # queue_name => options pairs
       americas.south:
+        auto_delete: true
+        durable: false
+        exclusive: false
+        handler: "MyApp::SouthAmericaHandler"
+        routing_key: "americas.south.#"
+      # or an array
+      - queue_name: americas.south
         auto_delete: true
         durable: false
         exclusive: false

--- a/lib/jackhammer/queue.rb
+++ b/lib/jackhammer/queue.rb
@@ -1,5 +1,7 @@
 module Jackhammer
   class Queue
+    attr_reader :queue, :handler_object
+
     def initialize(topic:, queue:, handler:, routing:)
       @topic = topic
       @queue = queue
@@ -8,10 +10,10 @@ module Jackhammer
     end
 
     def subscribe
-      @queue.subscribe do |delivery_info, properties, content|
+      queue.subscribe do |delivery_info, properties, content|
         Log.info { [delivery_info.inspect, properties.inspect].join(' || ') }
         Log.debug { content }
-        @handler_object.call content
+        handler_object.call content
       rescue StandardError => e
         Log.error e
         Jackhammer.configuration.exception_adapter.call e

--- a/lib/jackhammer/version.rb
+++ b/lib/jackhammer/version.rb
@@ -1,3 +1,3 @@
 module Jackhammer
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/jackhammer/topic_manager_spec.rb
+++ b/spec/jackhammer/topic_manager_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Jackhammer::TopicManager do
       allow(Jackhammer).to receive(:configuration) { config_double }
     end
 
-    context 'when Jackhammer.configuration.subscribe_yaml returns empty config' do
+    context 'when configuration yaml contains empty config' do
       let(:config_double) { double(yaml: {}) }
 
       specify { expect(subject).to eq({}) }
     end
 
-    context 'when Jackhammer.configuration.subscribe_yaml defines queues' do
+    context 'when configuration yaml defines queues as hash' do
       let(:yaml) do
         {
           'my_topic' => {
@@ -35,7 +35,93 @@ RSpec.describe Jackhammer::TopicManager do
       specify { expect(subject).to be_a Hash }
 
       describe '.topics[:my_topic]' do
-        specify { expect(subject[:my_topic]).to be_a Jackhammer::Topic }
+        specify do
+          expect(subject[:my_topic]).to be_a Jackhammer::Topic
+          expect(subject[:my_topic].queues).not_to be_empty
+          expect(subject[:my_topic].queues.first.queue.name).to eq('first_queue')
+        end
+      end
+    end
+
+    context 'when configuration yaml defines queues as array' do
+      let(:yaml) do
+        {
+          'my_topic' => {
+            'arguments' => true,
+            'auto_delete' => true,
+            'durable' => true,
+            'queues' => [
+              'queue_name' => 'first_queue',
+              'durable' => true,
+              'auto_delete' => false,
+              'handler' => 'FakeClient',
+              'routing_key' => 'first_queue.event'
+            ]
+          }
+        }
+      end
+      let(:config_double) { double(yaml: yaml) }
+
+      specify { expect(subject).to be_a Hash }
+
+      describe '.topics[:my_topic]' do
+        specify do
+          expect(subject[:my_topic]).to be_a Jackhammer::Topic
+          expect(subject[:my_topic].queues).not_to be_empty
+          expect(subject[:my_topic].queues.first.queue.name).to eq('first_queue')
+        end
+      end
+    end
+
+    context 'when configuration yaml defines contains invalid queue config without queue_name' do
+      let(:yaml) do
+        {
+          'my_topic' => {
+            'arguments' => true,
+            'auto_delete' => true,
+            'durable' => true,
+            'queues' => [
+              # no queue_name
+              'durable' => true,
+              'auto_delete' => false,
+              'handler' => 'FakeClient',
+              'routing_key' => 'first_queue.event'
+            ]
+          }
+        }
+      end
+      let(:config_double) { double(yaml: yaml) }
+
+      specify { expect(subject).to be_a Hash }
+
+      describe '.topics[:my_topic]' do
+        specify { expect { subject[:my_topic].queues }.to raise_error(InvalidConfigError) }
+      end
+    end
+
+    context 'when configuration yaml defines contains invalid queue config without routing_key' do
+      let(:yaml) do
+        {
+          'my_topic' => {
+            'arguments' => true,
+            'auto_delete' => true,
+            'durable' => true,
+            'queues' => [
+              'queue_name' => 'first_queue',
+              'durable' => true,
+              'auto_delete' => false,
+              'handler' => 'FakeClient',
+              # no routing_key
+            ]
+          }
+        }
+      end
+      let(:config_double) { double(yaml: yaml) }
+
+      specify { expect(subject).to be_a Hash }
+
+      describe '.topics[:my_topic]' do
+        specify { expect { subject[:my_topic].queues }.to raise_error(InvalidConfigError) }
       end
     end
   end


### PR DESCRIPTION
Current format of `jackhammer.yaml` does not allow to subscribe on multiple routing keys on same queue, since the queue name is a hash key. E.g.

```
foo.bar:
  auto_delete: false
  durable: true
  exclusive: false
  handler: "BlueHandler"
  routing_key: "foo.bar.blue.#"
foo.bar:
  auto_delete: false
  durable: true
  exclusive: false
  handler: "OrangeHandler"
  routing_key: "foo.bar.orange.#" 
```

To achieve that queue config needs be an array e.g:

```
- queue_name: foo.bar
  auto_delete: false
  durable: true
  exclusive: false
  handler: "BlueHandler"
  routing_key: "foo.bar.blue.#"
- queue_name: foo.bar
  auto_delete: false
  durable: true
  exclusive: false
  handler: "OrangeHandler"
  routing_key: "foo.bar.orange.#"
```