### PR TITLE
add specs to ensure multiple subscriptions under a queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ default: &default
         exclusive: false
         handler: "MyApp::SouthAmericaHandler"
         routing_key: "americas.south.#"
+      americas.north:
+        auto_delete: true
+        durable: false
+        exclusive: false
+        handler: "MyApp::NorthAmericaHandler"
+        routing_key: "americas.north.#"
 
 development:
   <<: *default

--- a/spec/jackhammer/topic_manager_spec.rb
+++ b/spec/jackhammer/topic_manager_spec.rb
@@ -26,7 +26,13 @@ RSpec.describe Jackhammer::TopicManager do
                 'durable' => true,
                 'auto_delete' => false,
                 'handler' => 'FakeClient',
-                'routing_key' => 'first_queue.event'
+                'routing_key' => 'first_queue.event_a'
+              },
+              'second_queue' => {
+                'durable' => false,
+                'auto_delete' => false,
+                'handler' => 'FakeClient',
+                'routing_key' => 'first_queue.event_b'
               }
             }
           }
@@ -35,9 +41,18 @@ RSpec.describe Jackhammer::TopicManager do
       let(:config_double) { double(yaml: yaml) }
 
       specify { expect(subject).to be_a Hash }
+      specify { expect(subject.keys).to eq [:my_topic] }
 
-      describe '.topics[:my_topic]' do
+      describe '[:my_topic]' do
         specify { expect(subject[:my_topic]).to be_a Jackhammer::Topic }
+
+        describe '#queues#first' do
+          specify { expect(subject[:my_topic].queues.first).to be_a Jackhammer::Queue }
+        end
+
+        describe '#queues#size' do
+          specify { expect(subject[:my_topic].queues.size).to eq 2 }
+        end
       end
     end
   end


### PR DESCRIPTION
Updating README and specs to showcase how to configure multiple subscriptions to the same queue.