### PR TITLE
Be more strict with queue config

### DIFF
--- a/lib/jackhammer/topic.rb
+++ b/lib/jackhammer/topic.rb
@@ -21,9 +21,9 @@ module Jackhammer
 
       @queues = @queue_config.map do |name, options|
         handler = MessageReceiver.new(options.delete('handler'))
-        routing = options.delete 'routing_key'
-        queue = Jackhammer.channel.queue name, options
-        Queue.new topic: @topic, queue: queue, handler: handler, routing: routing
+        routing = options.delete('routing_key') || fail(InvalidConfigError, "routing_key not found in #{options.inspect}")
+        queue = Jackhammer.channel.queue(name, options)
+        Queue.new(topic: @topic, queue: queue, handler: handler, routing: routing)
       end
     end
   end

--- a/spec/jackhammer/topic_manager_spec.rb
+++ b/spec/jackhammer/topic_manager_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Jackhammer::TopicManager do
       allow(Jackhammer).to receive(:configuration) { config_double }
     end
 
-    context 'when Jackhammer.configuration.subscribe_yaml returns empty config' do
+    context 'when configuration yaml contains empty config' do
       let(:config_double) { double(yaml: {}) }
 
       specify { expect(subject).to eq({}) }
     end
 
-    context 'when Jackhammer.configuration.subscribe_yaml defines queues' do
+    context 'when configuration yaml defines queues' do
       let(:yaml) do
         {
           'my_topic' => {
@@ -51,6 +51,41 @@ RSpec.describe Jackhammer::TopicManager do
         describe '#queues#size' do
           specify { expect(subject[:my_topic].queues.size).to eq 2 }
         end
+      end
+    end
+
+    context 'when configuration yaml contains invalid queue config' do
+      let(:yaml) do
+        {
+          'my_topic' => {
+            'arguments' => true,
+            'auto_delete' => true,
+            'durable' => true,
+            'queues' => {
+              'first_queue' => {
+                'durable' => true,
+                'auto_delete' => false,
+                'handler' => 'FakeClient',
+                # no routing_key
+              },
+              'second_queue' => {
+                'durable' => false,
+                'auto_delete' => false,
+                'handler' => 'FakeClient',
+                'routing_key' => 'first_queue.event_b'
+              }
+            }
+          }
+        }
+      end
+      let(:config_double) { double(yaml: yaml) }
+
+      specify { expect(subject).to be_a Hash }
+      specify { expect(subject.keys).to eq [:my_topic] }
+
+      describe '[:my_topic]' do
+        specify { expect(subject[:my_topic]).to be_a Jackhammer::Topic }
+        specify { expect { subject[:my_topic].queues }.to raise_error(InvalidConfigError) }
       end
     end
   end


### PR DESCRIPTION
In https://github.com/RenoFi/jackhammer/pull/17 I made an improvement with fetching queue config. Since we're rejected that PR, I picked the improvement here, so it's not lost.