### PR TITLE
Clear active AR connections after each handler call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (6.0.3.1)
+      activesupport (= 6.0.3.1)
+    activerecord (6.0.3.1)
+      activemodel (= 6.0.3.1)
+      activesupport (= 6.0.3.1)
+    activesupport (6.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     amq-protocol (2.3.1)
     ast (2.4.0)
     bunny (2.15.0)
@@ -14,7 +25,11 @@ GEM
     bunny-mock (1.7.0)
       bunny (>= 1.7)
     byebug (11.1.3)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.1)
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
@@ -34,24 +49,32 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.83.0)
+    rubocop (0.84.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
+      rubocop-ast (>= 0.0.3)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-performance (1.5.2)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
+    rubocop-performance (1.6.0)
       rubocop (>= 0.71.0)
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord
   bundler
   bunny-mock
   byebug

--- a/jackhammer.gemspec
+++ b/jackhammer.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bunny', '~> 2.14'
 
+  spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'bunny-mock'
   spec.add_development_dependency 'byebug'

--- a/lib/jackhammer/message_receiver.rb
+++ b/lib/jackhammer/message_receiver.rb
@@ -15,6 +15,8 @@ module Jackhammer
       else
         handler.call message
       end
+    ensure
+      ActiveRecord::Base.clear_active_connections! if defined?(ActiveRecord::Base)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'active_record'
 require 'jackhammer'
 require 'jackhammer/cli'
 require 'bunny-mock'


### PR DESCRIPTION
## Description
Clear active AR connections after each handler call

## Motivation and Context
When jackhammer handler is using AR, active connections needs to be cleared up. Let's handle it automatically and don't worry in each handler separately.

Similar solution as done in https://github.com/RenoFi/rack-graphql/blob/master/lib/rack_graphql/middleware.rb#L28. 