### PR TITLE
add Jackhammer::RakeTask to validate YAML configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: %i[rubocop:auto_correct spec]
+task default: %i[spec rubocop:auto_correct]

--- a/lib/jackhammer/configuration_validator.rb
+++ b/lib/jackhammer/configuration_validator.rb
@@ -1,0 +1,60 @@
+module Jackhammer
+  class ConfigurationValidator
+    attr_accessor :config_yaml, :environment, :errors
+
+    def initialize
+      @errors = []
+    end
+
+    def validate
+      validate_environment_defined
+      return if errors.any?
+      validate_topic_exchange_defined
+      return if errors.any?
+      validate_queues_defined
+      return if errors.any?
+      validate_handlers_defined
+    end
+
+    def validate_environment_defined
+      return if config_yaml[environment]
+
+      add_error("Environment '#{environment}' is not defined")
+    end
+
+    def validate_topic_exchange_defined
+      return if config_yaml[environment].keys.any?
+
+      add_error("Environment '#{environment}' does not define a topic exchange")
+    end
+
+    def validate_queues_defined
+      topics = config_yaml[environment].keys
+      topics.each do |topic|
+        begin
+          next if config_yaml[environment][topic]['queues']
+        rescue StandardError
+          false
+        end
+
+        add_error("Topic '#{topic}' does not define any queues")
+      end
+    end
+
+    def validate_handlers_defined
+      config_yaml[environment].each do |exchange_name, exchange_config|
+        exchange_config['queues'].each do |qconfig|
+          Object.const_get(qconfig['handler'])
+        rescue NameError
+          add_error("Uninitialized constant #{qconfig['handler']}")
+        end
+      end
+    end
+
+    private
+
+    def add_error(str)
+      @errors << str
+    end
+  end
+end

--- a/lib/jackhammer/rake_task.rb
+++ b/lib/jackhammer/rake_task.rb
@@ -1,0 +1,70 @@
+require 'rake'
+require 'rake/tasklib'
+require 'yaml'
+require 'jackhammer/configuration_validator'
+
+module Jackhammer
+  class RakeTask < ::Rake::TaskLib
+    # Name of test task. (default is :jackhammer)
+    attr_accessor :name
+
+    # File path of the configuration file. (default is ./config/jackhammer.yml)
+    attr_accessor :path
+
+    # Description of the test task. (default is 'Validate Jackhammer
+    # configuration')
+    attr_accessor :description
+
+    # Task prerequisites.
+    attr_accessor :deps
+
+    # Specifies the environment to inspect. (default is 'production')
+    attr_accessor :env
+
+    def initialize
+      @name = :jackhammer
+      @env = 'production'
+      @path = './config/jackhammer.yml'
+      @description = 'Validate Jackhammer configuration'
+      @deps = []
+      yield self if block_given?
+      if @name.is_a?(Hash)
+        @deps = @name.values.first
+        @name = @name.keys.first
+      end
+      define
+    end
+
+    def define
+      desc @description
+      task @name => Array(deps) do
+        validator = ConfigurationValidator.new
+        validator.config_yaml = YAML.safe_load(File.read(@path))
+        validator.environment = env
+        validator.validate
+        print_results validator.errors
+      end
+    end
+
+    private
+
+    def print_results(errors)
+      puts "Jackhammer configuration #{path}\n"
+      if errors.any?
+        puts red("Problems identified: #{errors.size}\n")
+        errors.each { |error| puts red(error) }
+        exit 1
+      else
+        puts green('OK')
+      end
+    end
+
+    def red(text)
+      "\e[1;31m#{text}\e[0m"
+    end
+
+    def green(text)
+      "\e[1;32m#{text}\e[0m"
+    end
+  end
+end

--- a/spec/jackhammer/configuration_validator_spec.rb
+++ b/spec/jackhammer/configuration_validator_spec.rb
@@ -1,0 +1,80 @@
+require 'jackhammer/configuration_validator'
+
+TestChicagoWeatherHandler = Class.new
+
+RSpec.describe Jackhammer::ConfigurationValidator do
+  describe '#errors' do
+    subject { validator.errors }
+
+    let(:validator) { described_class.new }
+
+    specify { expect(subject).to eq [] }
+
+    context 'with valid YAML' do
+      before do
+        validator.environment = 'production'
+        validator.config_yaml = YAML.safe_load <<~YAML
+          ---
+          production:
+            MyTopic:
+              queues:
+                - routing_key: 'weather.chicago'
+                  handler: TestChicagoWeatherHandler
+        YAML
+        validator.validate
+      end
+
+      specify { expect(subject).to eq [] }
+    end
+
+    context 'with wrong environment' do
+      before do
+        validator.environment = 'test'
+        validator.config_yaml = YAML.safe_load <<~YAML
+          ---
+          production:
+            MyTopic:
+              queues:
+                - routing_key: 'weather.chicago'
+                  handler: TestChicagoWeatherHandler
+        YAML
+        validator.validate
+      end
+
+      specify { expect(subject).to match_array ["Environment 'test' is not defined"] }
+    end
+
+    context 'with missing queues' do
+      before do
+        validator.environment = 'production'
+        validator.config_yaml = YAML.safe_load <<~YAML
+          ---
+          production:
+            MyTopic:
+              - routing_key: 'weather.chicago'
+                handler: TestChicagoWeatherHandler
+        YAML
+        validator.validate
+      end
+
+      specify { expect(subject).to match_array ["Topic 'MyTopic' does not define any queues"] }
+    end
+
+    context 'with an unknown constant' do
+      before do
+        validator.environment = 'production'
+        validator.config_yaml = YAML.safe_load <<~YAML
+          ---
+          production:
+            MyTopic:
+              queues:
+                - routing_key: 'weather.chicago'
+                  handler: TestHandlerAbC123
+        YAML
+        validator.validate
+      end
+
+      specify { expect(subject).to match_array ['Uninitialized constant TestHandlerAbC123'] }
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR adds a rake task that can be added to projects to ensure queue handler constants load ahead of receiving a message when the server is running.


Add the Rake task to your project
```ruby
    # Rakefile
    require 'jackhammer/rake_task'
    Jackhammer::RakeTask.new
```
Run the rake task to validate your YAML will forward messages to the
appropriate handler class.
```
    $ rake jackhammer
```
It will return an exit code of 1 if any errors are found.

## Motivation and Context
A typo has bitten me a few times, only to find out in staging that Thisconstant is not the same as ThisConstant 😄 

## How Has This Been Tested?
I've tested this both by hand with various config files. I've added unit tests to the actual validating PORO.
