### PR TITLE
Add support for defining middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,6 @@ class MyServerMiddleware
 end
 ```
 
-#### Server middleware
-
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ module MyApp
       config.publish_options    = { mandatory: true, persistent: true }
       config.yaml_config        = "config/jackhammer.yml"
       config.app_name           = "my_app"
+      config.client_middleware.use MyClientMiddleware, some_arg: 1, other_arg: 2
+      config.server_middleware.use MyServerMiddleware
     end
   end
 end
@@ -162,9 +164,48 @@ The intent of the options might not be obvious by looking at the name.
   overridden by passing the same options as arguments in your code).
 - **yaml_config** defines the file location of the Topic Exchange YAML
   configuration file.
+- **client_middleware** defines hooks that will be executed prior to publishing a message to a topic
+- **server_middleware** defines hooks that will be executed prior to running the message handler
 
 You can find defaults specified in the Jackhammer::Configuration class
 constructor.
+
+### Middleware
+
+Middleware allows you to hook into message publishing (client) and handling (server).
+
+It can be used to transform the passed in arguments before passing them along or to halt the execution completely.
+The execution will be halted if the middleware instance does not yield.
+
+#### Example client middleware
+
+```ruby
+class MyClientMiddleware
+  def initialize(name)
+    @name = name
+  end
+  
+  def call(message, options)
+    options[:headers][:hello] = @name
+
+    yield message, options
+  end
+end
+```
+
+#### Example server middleware
+
+```ruby
+class MyServerMiddleware
+  def call(handler:, delivery_info:, properties:, content:)
+    puts "Hello, #{properties[:headers]['name']}!"
+
+    yield handler: handler, delivery_info: delivery_info, properties: properties, content: content
+  end
+end
+```
+
+#### Server middleware
 
 ## Development
 

--- a/lib/jackhammer.rb
+++ b/lib/jackhammer.rb
@@ -7,6 +7,7 @@ require 'jackhammer/exceptions'
 require 'jackhammer/log'
 require 'jackhammer/configuration'
 require 'jackhammer/message_receiver'
+require 'jackhammer/middleware_collection'
 require 'jackhammer/queue_name'
 require 'jackhammer/queue'
 require 'jackhammer/topic'
@@ -45,6 +46,14 @@ module Jackhammer
         opts[:headers] ||= {}
         opts[:headers][:time] ||= time.iso8601
       end
+    end
+
+    def client_middleware
+      configuration.client_middleware
+    end
+
+    def server_middleware
+      configuration.server_middleware
     end
   end
 end

--- a/lib/jackhammer/configuration.rb
+++ b/lib/jackhammer/configuration.rb
@@ -2,6 +2,7 @@ module Jackhammer
   class Configuration
     attr_accessor(
       :app_name,
+      :client_middleware,
       :connection_options,
       :connection_url,
       :environment,
@@ -9,6 +10,7 @@ module Jackhammer
       :logger,
       :publish_options,
       :server,
+      :server_middleware,
       :yaml_config
     )
 
@@ -20,6 +22,8 @@ module Jackhammer
       @logger = Logger.new IO::NULL
       @publish_options = { mandatory: true, persistent: true }
       @yaml_config = './config/jackhammer.yml'
+      @client_middleware = MiddlewareCollection.new
+      @server_middleware = MiddlewareCollection.new
     end
 
     def self.instance

--- a/lib/jackhammer/middleware_collection.rb
+++ b/lib/jackhammer/middleware_collection.rb
@@ -9,12 +9,13 @@ module Jackhammer
     end
 
     def call(*args)
-      return yield *args if @entries.empty?
+      return yield(*args) if @entries.empty?
 
       middlewares = @entries.map(&:instantiate)
+
       traverse = proc do |*arguments|
         if middlewares.empty?
-          yield *arguments
+          yield(*arguments)
         else
           middleware = middlewares.shift
           middleware.call(*arguments, &traverse)

--- a/lib/jackhammer/middleware_collection.rb
+++ b/lib/jackhammer/middleware_collection.rb
@@ -1,0 +1,35 @@
+module Jackhammer
+  class MiddlewareCollection
+    def initialize
+      @entries = []
+    end
+
+    def use(klass, *args, &block)
+      @entries << Entry.new(klass: klass, args: args, block: block)
+    end
+
+    def call(*args)
+      return yield *args if @entries.empty?
+
+      middlewares = @entries.map(&:instantiate)
+      traverse = proc do |*arguments|
+        if middlewares.empty?
+          yield *arguments
+        else
+          middleware = middlewares.shift
+          middleware.call(*arguments, &traverse)
+        end
+      end
+
+      traverse.call(*args)
+    end
+
+    Entry = Struct.new(:klass, :args, :block, keyword_init: true) do
+      def instantiate
+        return klass unless klass.respond_to?(:new)
+
+        klass.new(*args, &block)
+      end
+    end
+  end
+end

--- a/lib/jackhammer/middleware_collection.rb
+++ b/lib/jackhammer/middleware_collection.rb
@@ -8,18 +8,11 @@ module Jackhammer
       @entries << Entry.new(klass: klass, args: args, block: block)
     end
 
-    def call(*args)
-      return yield(*args) if @entries.empty?
-
-      middlewares = @entries.map(&:instantiate)
+    def call(*args, &block)
+      call_chain = @entries.map(&:instantiate) + [block]
 
       traverse = proc do |*arguments|
-        if middlewares.empty?
-          yield(*arguments)
-        else
-          middleware = middlewares.shift
-          middleware.call(*arguments, &traverse)
-        end
+        call_chain.shift.call(*arguments, &traverse) unless call_chain.empty?
       end
 
       traverse.call(*args)

--- a/lib/jackhammer/queue.rb
+++ b/lib/jackhammer/queue.rb
@@ -13,7 +13,15 @@ module Jackhammer
       queue.subscribe do |delivery_info, properties, content|
         Log.info { [delivery_info.inspect, properties.inspect].join(' || ') }
         Log.debug { content }
-        handler_object.call content
+
+        Jackhammer.server_middleware.call(
+          handler: handler_object,
+          delivery_info: delivery_info,
+          properties: properties,
+          content: content
+        ) do |**args|
+          args.fetch(:handler).call args.fetch(:content)
+        end
       rescue StandardError => e
         Log.error e
         Jackhammer.configuration.exception_adapter.call e

--- a/lib/jackhammer/topic.rb
+++ b/lib/jackhammer/topic.rb
@@ -15,7 +15,9 @@ module Jackhammer
     # We're expecting the client to specify at least the routing_key in options
     # for each message published.
     def publish(message, options)
-      topic.publish message, Jackhammer.publish_options(options)
+      Jackhammer.client_middleware.call(message, Jackhammer.publish_options(options)) do |msg, opts|
+        topic.publish msg, opts
+      end
     end
 
     def queues

--- a/spec/jackhammer/middleware_collection_spec.rb
+++ b/spec/jackhammer/middleware_collection_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Jackhammer::MiddlewareCollection do
     it 'calls the passed in block' do
       expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123)
     end
+
+    it 'returns the value from the block' do
+      expect(middleware.call(:foo, bar: 123) { 'result' }).to eq('result')
+    end
   end
 
   context 'with some middleware specified' do
@@ -46,6 +50,10 @@ RSpec.describe Jackhammer::MiddlewareCollection do
 
     it 'executes the middleware in the same order as they were added' do
       expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123, baz: 3)
+    end
+
+    it 'returns the value from the block' do
+      expect(middleware.call(:foo, bar: 123) { 'result' }).to eq('result')
     end
   end
 

--- a/spec/jackhammer/middleware_collection_spec.rb
+++ b/spec/jackhammer/middleware_collection_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe Jackhammer::MiddlewareCollection do
+  subject(:middleware) { described_class.new }
+
+  let(:baz_appender_middleware_class) do
+    Class.new do
+      def initialize(value)
+        @value = value
+      end
+
+      def call(foo, opts)
+        opts[:baz] = @value
+        yield foo, opts
+      end
+    end
+  end
+
+  let(:show_stopper_middleware_class) do
+    Class.new do
+      def call(foo, opts)
+        # does not yield
+      end
+    end
+  end
+
+  context 'with no entries' do
+    it 'calls the passed in block' do
+      expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123)
+    end
+  end
+
+  context 'with some middleware specified' do
+    before do
+      middleware.use baz_appender_middleware_class, 234
+    end
+
+    it 'creates a middleware instance and passes args through it' do
+      expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123, baz: 234)
+    end
+  end
+
+  context 'with multiple middlewares specified' do
+    before do
+      middleware.use baz_appender_middleware_class, 1
+      middleware.use baz_appender_middleware_class, 2
+      middleware.use baz_appender_middleware_class, 3
+    end
+
+    it 'executes the middleware in the same order as they were added' do
+      expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123, baz: 3)
+    end
+  end
+
+  context 'when a middleware stops the chain execution' do
+    before do
+      middleware.use baz_appender_middleware_class, 1
+      middleware.use show_stopper_middleware_class
+      middleware.use baz_appender_middleware_class, 3
+    end
+
+    it 'does not execute the block' do
+      expect { |block| middleware.call(:foo, bar: 123, &block) }.not_to yield_control
+    end
+  end
+
+  context 'it accepts singleton/non-class middleware' do
+    before do
+      middleware.use(proc { |name, opts, &block| block.call(name, opts.merge(hello: 'from proc')) })
+    end
+
+    it 'does not execute the block' do
+      expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123, hello: 'from proc')
+    end
+  end
+end

--- a/spec/jackhammer/middleware_collection_spec.rb
+++ b/spec/jackhammer/middleware_collection_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Jackhammer::MiddlewareCollection do
       end
 
       def call(foo, opts)
-        opts[:baz] = @value
-        yield foo, opts
+        yield foo, opts.merge(baz: @value)
       end
     end
   end
@@ -62,12 +61,12 @@ RSpec.describe Jackhammer::MiddlewareCollection do
     end
   end
 
-  context 'it accepts singleton/non-class middleware' do
+  context 'with singleton/non-class middleware' do
     before do
       middleware.use(proc { |name, opts, &block| block.call(name, opts.merge(hello: 'from proc')) })
     end
 
-    it 'does not execute the block' do
+    it 'uses the given proc as-is and does not try to call new on it' do
       expect { |block| middleware.call(:foo, bar: 123, &block) }.to yield_with_args(:foo, bar: 123, hello: 'from proc')
     end
   end


### PR DESCRIPTION
## Description

There is separate middleware for the client (publishing) and the server
(subscribing). The middleware supports modifying the arguments and
halting the execution.

The implementation of the `MiddlewareCollection` is fairly rudimentary,
but allows for future quality of life enhancements, such as adding code
to `prepend` middleware, `remove` selected middleware, or insert
middleware directly after some other one.

## Motivation and Context

I need a way of hooking into Jackhammer so that I can set some custom headers (tracing related) and then on the server-side read them back and wrap the handler execution so that the tracing variables are available on the current thread.

## How Has This Been Tested?

Included in a project that uses `jackhammer` and tested both with custom middleware and without any middleware defined.
